### PR TITLE
Add FDSBP and allow different surface flux on boundary

### DIFF
--- a/examples/linear_advection.jl
+++ b/examples/linear_advection.jl
@@ -9,7 +9,7 @@ equations = LinearAdvectionEquation1D(advection_velocity)
 
 initial_condition = initial_condition_convergence_test
 
-# Create DG solver with polynomial degree = 3 and (local) Godunov flux as surface flux
+# Create DG solver with polynomial degree = 3 and Godunov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_godunov)
 
 coordinates_min = -1.0 # minimum coordinate

--- a/examples/linear_advection_Dirichlet_boundary_condition.jl
+++ b/examples/linear_advection_Dirichlet_boundary_condition.jl
@@ -12,7 +12,7 @@ function initial_condition_Gaussian(x, t, equations::LinearAdvectionEquation1D)
     return SVector(exp(-(x_trans + 0.5)^2 / 0.1))
 end
 
-# Create DG solver with polynomial degree = 3 and (local) Godunov flux as surface flux
+# Create DG solver with polynomial degree = 3 and Godunov flux as surface flux
 solver = DGSEM(polydeg = 3, surface_flux = flux_godunov)
 
 coordinates_min = -1.0 # minimum coordinate

--- a/examples/linear_advection_FDSBP.jl
+++ b/examples/linear_advection_FDSBP.jl
@@ -1,0 +1,42 @@
+using SimpleDiscontinuousGalerkin
+using OrdinaryDiffEqLowStorageRK
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advection_velocity = 2.0
+equations = LinearAdvectionEquation1D(advection_velocity)
+
+initial_condition = initial_condition_convergence_test
+
+coordinates_min = -1.0 # minimum coordinate
+coordinates_max = 1.0 # maximum coordinate
+
+# We couple the discontinuous Legendre derivative operator on a uniform mesh
+# directly with the tools from SummationByPartsOperators.jl to create a
+# global DG operator and we only use one big element here. This is equivalent to
+# using the DGSEM solver with polynomial degree 3 and a central flux.
+p = 3
+D_leg = legendre_derivative_operator(-1.0, 1.0, p + 1)
+N_elements = 10
+uniform_mesh = UniformMesh1D(coordinates_min, coordinates_max, N_elements)
+D = couple_discontinuously(D_leg, uniform_mesh)
+solver = FDSBP(D, surface_integral = SurfaceIntegralStrongForm(flux_godunov),
+               volume_integral = VolumeIntegralStrongForm())
+
+mesh = Mesh(coordinates_min, coordinates_max, 1) # use only one element because we already have a global operator
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+boundary_conditions = (x_neg = BoundaryConditionDirichlet(initial_condition),
+                       x_pos = boundary_condition_do_nothing)
+semi = Semidiscretization(mesh, equations, initial_condition, solver; boundary_conditions)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+saveat = range(tspan..., length = 100)
+sol = solve(ode, RDPK3SpFSAL49(), abstol = 1.0e-8, reltol = 1.0e-8,
+            saveat = saveat)

--- a/examples/linear_advection_FDSBP.jl
+++ b/examples/linear_advection_FDSBP.jl
@@ -15,7 +15,8 @@ coordinates_max = 1.0 # maximum coordinate
 # We couple the discontinuous Legendre derivative operator on a uniform mesh
 # directly with the tools from SummationByPartsOperators.jl to create a
 # global DG operator and we only use one big element here. This is equivalent to
-# using the DGSEM solver with polynomial degree 3 and a central flux.
+# using the DGSEM solver with polynomial degree 3 and a central flux in the interior
+# and the same flux on the boundary as is used here in the surface integral.
 p = 3
 D_leg = legendre_derivative_operator(-1.0, 1.0, p + 1)
 N_elements = 10

--- a/examples/linear_advection_FDSBP_SAT.jl
+++ b/examples/linear_advection_FDSBP_SAT.jl
@@ -1,0 +1,45 @@
+using SimpleDiscontinuousGalerkin
+using OrdinaryDiffEqLowStorageRK
+
+###############################################################################
+# semidiscretization of the linear advection equation
+
+advection_velocity = 2.0
+equations = LinearAdvectionEquation1D(advection_velocity)
+
+initial_condition = initial_condition_convergence_test
+
+coordinates_min = -1.0 # minimum coordinate
+coordinates_max = 1.0 # maximum coordinate
+
+# We couple the discontinuous Legendre derivative operator on a uniform mesh
+# directly with the tools from SummationByPartsOperators.jl to create a
+# global DG operator and we only use one big element here. This is equivalent to
+# using the DGSEM solver with polynomial degree 3 and a central flux for the interior
+# and a Godunov flux for the boundary. This is equivalent to the global SBP-SAT method
+# du = -a * (D * u) - M^{-1} * e_L * (e_L^T * u - g(t)),
+# where D is a discontinuously coupled Legendre derivative operator.
+p = 3
+D_leg = legendre_derivative_operator(-1.0, 1.0, p + 1)
+N_elements = 10
+uniform_mesh = UniformMesh1D(coordinates_min, coordinates_max, N_elements)
+D = couple_discontinuously(D_leg, uniform_mesh)
+solver = FDSBP(D, surface_integral = SurfaceIntegralStrongForm(flux_central, flux_godunov),
+               volume_integral = VolumeIntegralStrongForm())
+
+mesh = Mesh(coordinates_min, coordinates_max, 1) # use only one element because we already have a global operator
+
+# A semidiscretization collects data structures and functions for the spatial discretization
+boundary_conditions = (x_neg = BoundaryConditionDirichlet(initial_condition),
+                       x_pos = boundary_condition_do_nothing)
+semi = Semidiscretization(mesh, equations, initial_condition, solver; boundary_conditions)
+
+###############################################################################
+# ODE solvers, callbacks etc.
+
+# Create ODE problem with time span from 0.0 to 1.0
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+saveat = range(tspan..., length = 100)
+sol = solve(ode, RDPK3SpFSAL49(), abstol = 1.0e-8, reltol = 1.0e-8,
+            saveat = saveat)

--- a/examples/linear_advection_FDSBP_SAT.jl
+++ b/examples/linear_advection_FDSBP_SAT.jl
@@ -17,7 +17,7 @@ coordinates_max = 1.0 # maximum coordinate
 # global DG operator and we only use one big element here. This is equivalent to
 # using the DGSEM solver with polynomial degree 3 and a central flux for the interior
 # and a Godunov flux for the boundary. This is equivalent to the global SBP-SAT method
-# du = -a * (D * u) - M^{-1} * e_L * (e_L^T * u - g(t)),
+# du = -a * (D * u) - aM^{-1} * e_L * (e_L^T * u - g(t)),
 # where D is a discontinuously coupled Legendre derivative operator.
 p = 3
 D_leg = legendre_derivative_operator(-1.0, 1.0, p + 1)

--- a/examples/linear_advection_strong_form.jl
+++ b/examples/linear_advection_strong_form.jl
@@ -9,7 +9,7 @@ equations = LinearAdvectionEquation1D(advection_velocity)
 
 initial_condition = initial_condition_convergence_test
 
-# Create DG solver with polynomial degree = 3 and (local) Godunov flux as surface flux
+# Create DG solver with polynomial degree = 3 and Godunov flux as surface flux
 surface_flux = flux_godunov
 solver = DGSEM(polydeg = 3, surface_integral = SurfaceIntegralStrongForm(surface_flux),
                volume_integral = VolumeIntegralStrongForm())

--- a/src/SimpleDiscontinuousGalerkin.jl
+++ b/src/SimpleDiscontinuousGalerkin.jl
@@ -5,7 +5,7 @@ using Reexport: @reexport
 using SimpleUnPack: @unpack
 @reexport using StaticArrays: SVector
 @reexport using SummationByPartsOperators
-import SummationByPartsOperators: grid
+import SummationByPartsOperators: AbstractDerivativeOperator, grid
 @reexport using TrixiBase: trixi_include
 using TrixiBase: TrixiBase, @trixi_timeit, timer
 
@@ -21,7 +21,7 @@ export initial_condition_convergence_test
 export Mesh, grid
 export boundary_condition_periodic, boundary_condition_do_nothing,
        BoundaryConditionDirichlet
-export DGSEM, VolumeIntegralStrongForm, VolumeIntegralWeakForm,
+export DGSEM, FDSBP, VolumeIntegralStrongForm, VolumeIntegralWeakForm,
        SurfaceIntegralStrongForm, SurfaceIntegralWeakForm
 export Semidiscretization, semidiscretize
 end

--- a/src/solvers/dgsem.jl
+++ b/src/solvers/dgsem.jl
@@ -36,7 +36,7 @@ function create_cache(mesh, equations, dg::DGSEM, initial_condition,
     # compute all mapped GLL nodes
     x = zeros(real(dg), nnodes(dg), nelements(mesh))
     for element in eachelement(mesh)
-        x_l = -1 + (element - 1) * dx + dx / 2
+        x_l = xmin(mesh) + (element - 1) * dx + dx / 2
         for (j, xi_j) in enumerate(grid(dg)) # GLL nodes in [-1, 1]
             x[j, element] = x_l + dx / 2 * xi_j
         end

--- a/src/solvers/dgsem.jl
+++ b/src/solvers/dgsem.jl
@@ -30,14 +30,38 @@ end
 
 Base.summary(io::IO, dg::DGSEM) = print(io, "DGSEM(polydeg=$(polydeg(dg)))")
 
-function create_cache(mesh, equations, dg::DGSEM, initial_condition,
+"""
+    FDSBP(D; RealT=Float64,
+             surface_flux=flux_central,
+             surface_integral=SurfaceIntegralWeakForm(surface_flux),
+             volume_integral=VolumeIntegralWeakForm(),
+             mortar=MortarL2(basis))
+
+Create a discontinuous Galerkin method using a summation-by-parts operator
+`D` from SummationByPartsOperators.jl. This is similar to the `DGSEM`, but uses
+a general derivative operator instead of a Legendre derivative operator.
+"""
+const FDSBP = DG{Basis} where {Basis <: AbstractDerivativeOperator}
+
+function FDSBP(D; RealT = Float64,
+               surface_flux = flux_central,
+               surface_integral = SurfaceIntegralWeakForm(surface_flux),
+               volume_integral = VolumeIntegralWeakForm())
+    basis = D
+    return DG{typeof(basis), typeof(surface_integral),
+              typeof(volume_integral)}(basis, surface_integral, volume_integral)
+end
+
+Base.summary(io::IO, dg::FDSBP) = print(io, "FDSBP(D=$D)")
+
+function create_cache(mesh, equations, dg::Union{DGSEM, FDSBP}, initial_condition,
                       boundary_conditions)
     dx = (xmax(mesh) - xmin(mesh)) / nelements(mesh) # length of each element
     # compute all mapped GLL nodes
     x = zeros(real(dg), nnodes(dg), nelements(mesh))
     for element in eachelement(mesh)
         x_l = xmin(mesh) + (element - 1) * dx + dx / 2
-        for (j, xi_j) in enumerate(grid(dg)) # GLL nodes in [-1, 1]
+        for (j, xi_j) in enumerate(grid(dg))
             x[j, element] = x_l + dx / 2 * xi_j
         end
     end
@@ -47,7 +71,7 @@ function create_cache(mesh, equations, dg::DGSEM, initial_condition,
     return cache
 end
 
-function apply_jacobian!(du, mesh, equations, dg::DGSEM, cache)
+function apply_jacobian!(du, mesh, equations, dg::Union{DGSEM, FDSBP}, cache)
     (; dx) = cache
     @. du = (2 / dx) * du
 end

--- a/src/solvers/integrals.jl
+++ b/src/solvers/integrals.jl
@@ -108,13 +108,18 @@ boundary fluxes.
 
 See also [`VolumeIntegralStrongForm`](@ref).
 """
-struct SurfaceIntegralStrongForm{SurfaceFlux, SurfaceFluxBoundary} <: AbstractSurfaceIntegral
+struct SurfaceIntegralStrongForm{SurfaceFlux, SurfaceFluxBoundary} <:
+       AbstractSurfaceIntegral
     surface_flux::SurfaceFlux
     surface_flux_boundary::SurfaceFluxBoundary
 end
 
-SurfaceIntegralStrongForm(surface_flux::Tuple) = SurfaceIntegralStrongForm(surface_flux[1], surface_flux[2])
-SurfaceIntegralStrongForm(surface_flux) = SurfaceIntegralStrongForm(surface_flux, surface_flux)
+function SurfaceIntegralStrongForm(surface_flux::Tuple)
+    SurfaceIntegralStrongForm(surface_flux[1], surface_flux[2])
+end
+function SurfaceIntegralStrongForm(surface_flux)
+    SurfaceIntegralStrongForm(surface_flux, surface_flux)
+end
 SurfaceIntegralStrongForm() = SurfaceIntegralStrongForm(flux_central)
 
 function create_cache(mesh, equations, solver, ::SurfaceIntegralStrongForm)
@@ -182,7 +187,9 @@ struct SurfaceIntegralWeakForm{SurfaceFlux, SurfaceFluxBoundary} <: AbstractSurf
     surface_flux_boundary::SurfaceFluxBoundary
 end
 
-SurfaceIntegralWeakForm(surface_flux::Tuple) = SurfaceIntegralWeakForm(surface_flux[1], surface_flux[2])
+function SurfaceIntegralWeakForm(surface_flux::Tuple)
+    SurfaceIntegralWeakForm(surface_flux[1], surface_flux[2])
+end
 SurfaceIntegralWeakForm(surface_flux) = SurfaceIntegralWeakForm(surface_flux, surface_flux)
 SurfaceIntegralWeakForm() = SurfaceIntegralWeakForm(flux_central)
 

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -17,3 +17,13 @@ end
     @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
                                               "linear_advection_strong_form.jl"))
 end
+
+@testitem "linear_advection_FDSBP.jl" setup=[Examples] begin
+    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
+                                              "linear_advection_FDSBP.jl"))
+end
+
+@testitem "linear_advection_FDSBP_SAT.jl" setup=[Examples] begin
+    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
+                                              "linear_advection_FDSBP_SAT.jl"))
+end


### PR DESCRIPTION
The following setups are equivalent and give the exact same results (up to floating point errors):

1.
- Use `legendre_derivative_operator`, which is coupled via `couple_discontinuously` and use only one element in `FDSBP` with `flux_central`.
- `DGSEM` with `flux_central` and as many elements as used in the coupling and `flux_central`.
2.
- Use `legendre_derivative_operator`, which is coupled via `couple_discontinuously` and use only one element in `FDSBP` with `flux_godunov`.
- `DGSEM` with `flux_central` as interior and `flux_godunov`as boundary flux and as many elements as used in the coupling and `flux_central`.
- Direct implementation only with SummationByPartsOperators.jl and `legendre_derivative_operator`, which is coupled via `couple_discontinuously` and using the classical SAT term $-aM^{-1}e_L(e_L^T u - g(t))$.

This makes sense since the discontinuously coupled `legendre_derivative_operator` acts the same as `DGSEM` with central flux *in the interior*. The global SBP-SAT formulation uses a Godunov flux on the boundary. Thus, to obtain equivalence, we need to allow using different surface flux in the interior as at the boundary.
Mostly independent of this PR, but to complete the equivalences: Strong form and weak form give the exact same results (for SBP operators) as the theory gives us.