### PR TITLE
Test for L2 and Linf errors

### DIFF
--- a/examples/linear_advection_FD.jl
+++ b/examples/linear_advection_FD.jl
@@ -16,7 +16,7 @@ D = derivative_operator(MattssonNordström2004(), 1, 2, -0.2, 0.2, 5)
 solver = FDSBP(D, surface_integral = SurfaceIntegralStrongForm(flux_godunov),
                volume_integral = VolumeIntegralStrongForm())
 
-mesh = Mesh(coordinates_min, coordinates_max, 20) # use only one element because we already have a global operator
+mesh = Mesh(coordinates_min, coordinates_max, 20)
 
 # A semidiscretization collects data structures and functions for the spatial discretization
 boundary_conditions = (x_neg = BoundaryConditionDirichlet(initial_condition),

--- a/examples/linear_advection_FDSBP_SAT.jl
+++ b/examples/linear_advection_FDSBP_SAT.jl
@@ -24,6 +24,7 @@ D_leg = legendre_derivative_operator(-1.0, 1.0, p + 1)
 N_elements = 10
 uniform_mesh = UniformMesh1D(coordinates_min, coordinates_max, N_elements)
 D = couple_discontinuously(D_leg, uniform_mesh)
+# The interior flux doesn't matter here because we only have one element.
 solver = FDSBP(D, surface_integral = SurfaceIntegralStrongForm(flux_central, flux_godunov),
                volume_integral = VolumeIntegralStrongForm())
 

--- a/examples/linear_advection_flux_differencing.jl
+++ b/examples/linear_advection_flux_differencing.jl
@@ -17,7 +17,7 @@ solver = DGSEM(polydeg = 3, surface_integral = SurfaceIntegralWeakForm(surface_f
 coordinates_min = -1.0 # minimum coordinate
 coordinates_max = 1.0 # maximum coordinate
 
-N_elements = 8 # number of elements
+N_elements = 10 # number of elements
 mesh = Mesh(coordinates_min, coordinates_max, N_elements)
 
 # A semidiscretization collects data structures and functions for the spatial discretization

--- a/examples/linear_advection_flux_differencing_strong_form.jl
+++ b/examples/linear_advection_flux_differencing_strong_form.jl
@@ -17,7 +17,7 @@ solver = DGSEM(polydeg = 3, surface_integral = SurfaceIntegralStrongForm(surface
 coordinates_min = -1.0 # minimum coordinate
 coordinates_max = 1.0 # maximum coordinate
 
-N_elements = 8 # number of elements
+N_elements = 10 # number of elements
 mesh = Mesh(coordinates_min, coordinates_max, N_elements)
 
 # A semidiscretization collects data structures and functions for the spatial discretization

--- a/src/SimpleDiscontinuousGalerkin.jl
+++ b/src/SimpleDiscontinuousGalerkin.jl
@@ -31,13 +31,14 @@ include("solvers/solver.jl")
 include("semidiscretization.jl")
 include("callbacks_step/callbacks_step.jl")
 
-export cons2cons
+export cons2cons, eachvariable, nvariables
 export LinearAdvectionEquation1D
 export flux, flux_central, flux_godunov
 export initial_condition_convergence_test
 export Mesh
 export boundary_condition_periodic, boundary_condition_do_nothing,
        BoundaryConditionDirichlet
+export eachnode, nnodes, nelements, nelements, ndofs
 export DGSEM, FDSBP,
        VolumeIntegralStrongForm, VolumeIntegralWeakForm,
        VolumeIntegralFluxDifferencing, VolumeIntegralFluxDifferencingStrongForm,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,7 @@ using TestItems
 using TestItemRunner
 
 @run_package_tests
+
+@testsnippet Setup begin
+    include("test_util.jl")
+end

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,44 +1,68 @@
 @testsnippet Examples begin
-    using TrixiBase: trixi_include
-    using TrixiTest: @trixi_test_nowarn
     examples_dir() = pkgdir(SimpleDiscontinuousGalerkin, "examples")
 end
 
-@testitem "linear_advection.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(), "linear_advection.jl"))
+@testitem "linear_advection.jl" setup=[Setup, Examples] begin
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection.jl"),
+                        l2=[0.00016123961626763236], linf=[0.00042895011704513486])
+
+    surface_flux = (flux_central, flux_godunov)
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection.jl"),
+                        surface_flux=surface_flux,
+                        l2=[0.00041060056908958845], linf=[0.0008162855376093736])
 end
 
-@testitem "linear_advection_Dirichlet_boundary_condition.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_Dirichlet_boundary_condition.jl"))
+@testitem "linear_advection_Dirichlet_boundary_condition.jl" setup=[Setup, Examples] begin
+    @test_trixi_include(joinpath(examples_dir(),
+                                 "linear_advection_Dirichlet_boundary_condition.jl"),
+                        l2=[0.00015725543332057758], linf=[0.0006856564226139367])
 end
 
-@testitem "linear_advection_strong_form.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_strong_form.jl"))
+@testitem "linear_advection_strong_form.jl" setup=[Setup, Examples] begin
+    # Same errors as in "linear_advection.jl"
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection_strong_form.jl"),
+                        l2=[0.00016123961626768018], linf=[0.0004289501170468002])
 end
 
-@testitem "linear_advection_FDSBP.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_FDSBP.jl"))
+@testitem "linear_advection_FDSBP.jl" setup=[Setup, Examples] begin
+    # Same errors as in "linear_advection.jl"
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection_strong_form.jl"),
+                        l2=[0.00016123961626768018], linf=[0.0004289501170468002])
 end
 
-@testitem "linear_advection_FDSBP_SAT.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_FDSBP_SAT.jl"))
+@testitem "linear_advection_FDSBP_SAT.jl" setup=[Setup, Examples] begin
+    # (Almost) same errors as in "linear_advection.jl" with `surface_flux = (flux_central, flux_godunov)`
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection_FDSBP_SAT.jl"),
+                        l2=[0.00040873810317442036], linf=[0.0008088018130785191])
 end
 
-@testitem "linear_advection_FD.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_FD.jl"))
+@testitem "linear_advection_FD.jl" setup=[Setup, Examples] begin
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection_FD.jl"),
+                        l2=[0.015581091289174379], linf=[0.031230470786942688])
+
+    # Use `legendre_derivative_operator` to test if `FDSBP` gives the same result`
+    coordinates_min = -1.0
+    coordinates_max = 1.0
+    mesh = Mesh(coordinates_min, coordinates_max, 10)
+    D = legendre_derivative_operator(-1.0, 1.0, 4)
+    solver = FDSBP(D, surface_integral = SurfaceIntegralStrongForm(flux_godunov),
+                   volume_integral = VolumeIntegralStrongForm())
+    semi = Semidiscretization(mesh, equations, initial_condition, solver)
+    # Same errors as in "linear_advection.jl"
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection_FD.jl"),
+                        semi=semi,
+                        l2=[0.00016123961626768018], linf=[0.0004289501170468002])
 end
 
-@testitem "linear_advection_flux_differencing.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_flux_differencing.jl"))
+@testitem "linear_advection_flux_differencing.jl" setup=[Setup, Examples] begin
+    # Same errors as in "linear_advection.jl"
+    @test_trixi_include(joinpath(examples_dir(), "linear_advection_flux_differencing.jl"),
+                        l2=[0.00016123961626813603], linf=[0.0004289501170472443])
 end
 
-@testitem "linear_advection_flux_differencing_strong_form.jl" setup=[Examples] begin
-    @trixi_test_nowarn trixi_include(joinpath(examples_dir(),
-                                              "linear_advection_flux_differencing_strong_form.jl"))
+@testitem "linear_advection_flux_differencing_strong_form.jl" setup=[Setup, Examples] begin
+    # Same errors as in "linear_advection.jl"
+    @test_trixi_include(joinpath(examples_dir(),
+                                 "linear_advection_flux_differencing_strong_form.jl"),
+                        l2=[0.00016123961626769392], linf=[0.00042895011704957575])
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,0 +1,68 @@
+using Test: @test
+using TrixiTest: @trixi_test_nowarn
+
+# Use a macro to avoid world age issues when defining new initial conditions etc.
+# inside an example.
+"""
+    @test_trixi_include(example; l2=nothing, linf = nothing,
+                                 atol=1e-12, rtol=sqrt(eps()))
+
+Test by calling `trixi_include(example; parameters...)`.
+By default, only the absence of error output is checked.
+If `l2` of `linf` are specified, in addition the resulting L2/Linf errors for each
+variable are compared approximately against these reference values, using
+`atol, rtol` as absolute/relative tolerance.
+"""
+macro test_trixi_include(example, args...)
+    local l2 = get_kwarg(args, :l2, nothing)
+    local linf = get_kwarg(args, :linf, nothing)
+    local atol = get_kwarg(args, :atol, 1e-12)
+    local rtol = get_kwarg(args, :rtol, sqrt(eps()))
+
+    local kwargs = Pair{Symbol, Any}[]
+    for arg in args
+        if (arg.head == :(=) &&
+            !(arg.args[1] in (:l2, :linf, :atol, :rtol)))
+            push!(kwargs, Pair(arg.args...))
+        end
+    end
+
+    quote
+        println("═"^100)
+        println($example)
+
+        # evaluate examples in the scope of the module they're called from
+        @trixi_test_nowarn trixi_include(@__MODULE__, $example; $kwargs...)
+
+        if !isnothing($l2) || !isnothing($linf)
+            # TODO: This should use the proper L2/Linf norms based on the basis of the solver, probably
+            # also implemented as `AnalysisCallback`
+            ini_cond = semi.initial_condition.(grid(semi), sol.t[end], equations)
+            for v in eachvariable(equations)
+                diff = vec(sol.u[end][v, :, :]) .- vec(getindex.(ini_cond, v))
+                l2 = sqrt(sum(diff .^ 2) / (ndofs(semi)))
+                linf = maximum(abs.(diff))
+                if !isnothing($l2)
+                    @test isapprox(l2, $l2[v], atol = $atol, rtol = $rtol)
+                end
+                if !isnothing($linf)
+                    @test isapprox(linf, $linf[v], atol = $atol, rtol = $rtol)
+                end
+            end
+        end
+        println("═"^100)
+    end
+end
+
+# Get the first value assigned to `keyword` in `args` and return `default_value`
+# if there are no assignments to `keyword` in `args`.
+function get_kwarg(args, keyword, default_value)
+    val = default_value
+    for arg in args
+        if arg.head == :(=) && arg.args[1] == keyword
+            val = arg.args[2]
+            break
+        end
+    end
+    return val
+end


### PR DESCRIPTION
This only uses naive L2 and Linf errors not taking into account the basis (SBP operator) for integrating. But it should at least give a descent security that we do not break anything in the future. Once an `AnalysisCallback` with correct L2 and Linf errors is implemented, this should also be used in the tests.
This is also useful to see, which of the different methods are equivalent and therefore give the same errors, see also https://github.com/JoshuaLampert/SimpleDiscontinuousGalerkin.jl/pull/4#issue-3063066495