### PR TITLE
Reorganize cache for overset grid method

### DIFF
--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -338,8 +338,8 @@ function analyze(quantity, du, u, t, semi::Semidiscretization)
 end
 
 function analyze(::typeof(entropy_timederivative), du, u, t, semi::Semidiscretization)
-    mesh, equations, solver, _ = mesh_equations_solver_cache(semi)
-    quantity = get_tmp_cache_scalar(semi)
+    mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
+    quantity = get_tmp_cache_scalar(cache)
     compute_quantity_timederivative!(quantity, cons2entropy, du, u, mesh, equations, solver)
     return integrate(quantity, semi)
 end

--- a/src/callbacks_step/stepsize.jl
+++ b/src/callbacks_step/stepsize.jl
@@ -76,18 +76,18 @@ end
 function calculate_dt(u, t, cfl_number::Real, semi)
     mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
 
-    dt = cfl_number * max_dt(u, t, mesh, equations, solver, cache.jacobian)
+    dt = cfl_number * max_dt(u, t, mesh, equations, solver, cache)
     return dt
 end
 # Case for `cfl_number` as a function of time `t`.
 function calculate_dt(u, t, cfl_number, semi)
     mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
 
-    dt = cfl_number(t) * max_dt(u, t, mesh, equations, solver, cache.jacobian)
+    dt = cfl_number(t) * max_dt(u, t, mesh, equations, solver, cache)
     return dt
 end
 
-function max_dt(u, t, mesh, equations, dg, jacobian)
+function max_dt(u, t, mesh, equations, dg, cache)
     # to avoid a division by zero if the speed vanishes everywhere,
     # e.g. for steady-state linear advection
     max_scaled_speed = nextfloat(zero(t))
@@ -103,7 +103,7 @@ function max_dt(u, t, mesh, equations, dg, jacobian)
         # in contrast to Trixi.jl, it is not always on the reference element [-1, 1].
         basis = get_basis(dg, element)
         dx_basis = last(grid(basis)) - first(grid(basis))
-        inv_jacobian = 1 / (dx_basis * jacobian[element])
+        inv_jacobian = 1 / (dx_basis * cache.jacobian[element])
         max_scaled_speed = max(max_scaled_speed, inv_jacobian * max_lambda1)
     end
 

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -88,7 +88,7 @@ end
 @inline ndofs(semi::Semidiscretization) = ndofs(semi.mesh, semi.solver)
 @inline Base.real(semi::Semidiscretization) = real(semi.mesh)
 
-get_tmp_cache_scalar(semi::Semidiscretization) = semi.cache.tmp_scalar
+get_tmp_cache_scalar(cache) = cache.tmp_scalar
 
 """
     grid(semi)
@@ -150,7 +150,7 @@ end
 
 # Here, `func` is a function that takes a vector at one node and the equations, e.g., `mass` or `entropy`.
 function integrate_quantity(func, u, semi::Semidiscretization)
-    quantity = get_tmp_cache_scalar(semi)
+    quantity = get_tmp_cache_scalar(semi.cache)
     integrate_quantity!(quantity, func, u, semi)
 end
 

--- a/src/semidiscretization/semidiscretization_overset_grid.jl
+++ b/src/semidiscretization/semidiscretization_overset_grid.jl
@@ -208,7 +208,6 @@ function PolynomialBases.integrate(func,
     mesh_left, mesh_right = semi.mesh.mesh_left, semi.mesh.mesh_right
     solver_left, solver_right = semi.solver
     l_left = left_overlap_element(semi.mesh)
-    l_right = right_overlap_element(semi.mesh)
     # TODO: This integrates the left domain only until the left boundary of the left overlap element,
     # i.e., we miss the integral from the left boundary of the left overlap element to b.
     # TODO: Which part should be integrated in the overlap region? This uses the right mesh,
@@ -216,11 +215,11 @@ function PolynomialBases.integrate(func,
     integral_left = sum(integrate_on_element(func, u_left.u[element],
                                              get_basis(solver_left, element), element,
                                              jacobian_left)
-                        for element in 1:nelements(mesh_left))
+                        for element in 1:l_left)
     integral_right = sum(integrate_on_element(func, u_right.u[element],
                                               get_basis(solver_right, element),
                                               element, jacobian_right)
-                         for element in l_right:nelements(mesh_right))
+                         for element in 1:nelements(mesh_right))
     return integral_left + integral_right
 end
 

--- a/src/semidiscretization/semidiscretization_overset_grid.jl
+++ b/src/semidiscretization/semidiscretization_overset_grid.jl
@@ -8,13 +8,6 @@ function ndofs(mesh::OversetGridMesh, solver::Tuple)
     return ndofs(mesh_left, solver_left) + ndofs(mesh_right, solver_right)
 end
 
-function compute_integral_operator(mesh, solver::Tuple, integral; kwargs...)
-    mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
-    solver_left, solver_right = solver
-    return (compute_integral_operator(mesh_left, solver_left, integral; kwargs...),
-            compute_integral_operator(mesh_right, solver_right, integral; kwargs...))
-end
-
 function allocate_coefficients(mesh::OversetGridMesh, equations, solver::Tuple)
     solver_left, solver_right = solver
     u_left = allocate_coefficients(mesh.mesh_left, equations, solver_left)

--- a/src/semidiscretization/semidiscretization_overset_grid.jl
+++ b/src/semidiscretization/semidiscretization_overset_grid.jl
@@ -2,11 +2,6 @@ SemidiscretizationOversetGrid = Semidiscretization{<:OversetGridMesh}
 
 digest_solver(::OversetGridMesh, solver::Union{DGSEM, FDSBP}) = (solver, solver)
 
-# This allows us to treat a `Tuple` of `Solver`s as a `Solver`.
-function Base.getproperty(solver::Tuple{S1, S2}, name::Symbol) where {S1 <: DG, S2 <: DG}
-    return getproperty(solver[1], name)
-end
-
 function ndofs(mesh::OversetGridMesh, solver::Tuple)
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
@@ -20,22 +15,6 @@ function compute_integral_operator(mesh, solver::Tuple, integral; kwargs...)
             compute_integral_operator(mesh_right, solver_right, integral; kwargs...))
 end
 
-function create_jacobian_and_node_coordinates(mesh::OversetGridMesh, solver::Tuple)
-    solver_left, solver_right = solver
-    jacobian_left, x_left = create_jacobian_and_node_coordinates(mesh.mesh_left,
-                                                                 solver_left)
-    jacobian_right, x_right = create_jacobian_and_node_coordinates(mesh.mesh_right,
-                                                                   solver_right)
-    return (jacobian_left, jacobian_right), (x_left, x_right)
-end
-
-function create_tmp_scalar(mesh::OversetGridMesh, solver)
-    solver_left, solver_right = solver
-    tmp_scalar_left = create_tmp_scalar(mesh.mesh_left, solver_left)
-    tmp_scalar_right = create_tmp_scalar(mesh.mesh_right, solver_right)
-    return VectorOfArray([tmp_scalar_left, tmp_scalar_right])
-end
-
 function allocate_coefficients(mesh::OversetGridMesh, equations, solver::Tuple)
     solver_left, solver_right = solver
     u_left = allocate_coefficients(mesh.mesh_left, equations, solver_left)
@@ -43,15 +22,19 @@ function allocate_coefficients(mesh::OversetGridMesh, equations, solver::Tuple)
     return VectorOfArray([u_left, u_right])
 end
 
-function compute_coefficients!(u, func, t, mesh::OversetGridMesh, equations, solver,
-                               cache, node_coordinates)
+function compute_coefficients!(u, func, t, mesh::OversetGridMesh, equations, solver, cache)
     u_left, u_right = u
-    node_coordinates_left, node_coordinates_right = node_coordinates
     solver_left, solver_right = solver
-    compute_coefficients!(u_left, func, t, mesh.mesh_left, equations, solver_left, cache,
-                          node_coordinates_left)
-    compute_coefficients!(u_right, func, t, mesh.mesh_right, equations, solver_right, cache,
-                          node_coordinates_right)
+    cache_left, cache_right = cache
+    compute_coefficients!(u_left, func, t, mesh.mesh_left, equations, solver_left,
+                          cache_left)
+    compute_coefficients!(u_right, func, t, mesh.mesh_right, equations, solver_right,
+                          cache_right)
+end
+
+function grid(semi::SemidiscretizationOversetGrid)
+    cache_left, cache_right = semi.cache
+    return (cache_left.node_coordinates, cache_right.node_coordinates)
 end
 
 function flat_grid(semi::SemidiscretizationOversetGrid)
@@ -65,75 +48,81 @@ function get_variable(u, v, semi::SemidiscretizationOversetGrid)
     return get_variable(u_left, v, solver_left), get_variable(u_right, v, solver_right)
 end
 
-function calc_volume_integral!(du, u, mesh::OversetGridMesh, equations,
-                               integral::Union{VolumeIntegralStrongForm,
-                                               VolumeIntegralWeakForm},
-                               solver, cache)
-    u_left, u_right = u
+function create_cache(mesh::OversetGridMesh, equations, solver)
+    solver_left, solver_right = solver
+    mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
+    cache_left = create_cache(mesh_left, equations, solver_left)
+    cache_right = create_cache(mesh_right, equations, solver_right)
+    return (; cache_left, cache_right)
+end
+
+function rhs!(du, u, t, mesh::OversetGridMesh, equations, initial_condition,
+              boundary_conditions, solver, cache)
     du_left, du_right = du
-    mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
-    solver_left, solver_right = solver
-    volume_operator_left, volume_operator_right = cache.volume_operator
-    f_all_left, f_all_right = cache.f_all
-    calc_volume_integral!(du_left, u_left, mesh_left, equations,
-                          integral, solver_left, volume_operator_left, f_all_left)
-    calc_volume_integral!(du_right, u_right, mesh_right, equations,
-                          integral, solver_right, volume_operator_right, f_all_right)
-end
-
-function calc_volume_integral!(du, u, mesh::OversetGridMesh, equations,
-                               integral::Union{VolumeIntegralFluxDifferencing,
-                                               VolumeIntegralFluxDifferencingStrongForm},
-                               solver, cache::NamedTuple)
     u_left, u_right = u
-    du_left, du_right = du
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
-    volume_operator_left, volume_operator_right = cache.volume_operator
-    calc_volume_integral!(du_left, u_left, mesh_left, equations,
-                          integral, solver_left, volume_operator_left)
-    calc_volume_integral!(du_right, u_right, mesh_right, equations,
-                          integral, solver_right, volume_operator_right)
-end
+    cache_left, cache_right = cache
 
-function create_cache_surface_flux_values(mesh::OversetGridMesh, equations, solver)
-    solver_left, solver_right = solver
-    surface_flux_values_left = create_cache_surface_flux_values(mesh.mesh_left, equations,
-                                                                solver_left)
-    surface_flux_values_right = create_cache_surface_flux_values(mesh.mesh_right, equations,
-                                                                 solver_right)
-    surface_flux_values = VectorOfArray([
-                                            surface_flux_values_left,
-                                            surface_flux_values_right
-                                        ])
-    return surface_flux_values
-end
+    @trixi_timeit timer() "reset ∂u/∂t" begin
+        reset_du!(du_left)
+        reset_du!(du_right)
+    end
 
-function calc_interface_flux!(surface_flux_values, u, mesh::OversetGridMesh, equations,
-                              integral::AbstractSurfaceIntegral, solver, cache)
-    u_left, u_right = u
-    surface_flux_values_left, surface_flux_values_right = surface_flux_values
-    mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
-    solver_left, solver_right = solver
-    calc_interface_flux!(surface_flux_values_left, u_left, mesh_left,
-                         equations, integral, solver_left, cache)
-    calc_interface_flux!(surface_flux_values_right, u_right, mesh_right,
-                         equations, integral, solver_right, cache)
+    @trixi_timeit timer() "volume integral" begin
+        calc_volume_integral!(du_left, u_left, mesh_left, equations,
+                              solver_left.volume_integral, solver_left, cache_left)
+        calc_volume_integral!(du_right, u_right, mesh_right, equations,
+                              solver_right.volume_integral, solver_right, cache_right)
+    end
+
+    @trixi_timeit timer() "interface flux" begin
+        calc_interface_flux!(cache_left.surface_flux_values, u_left, mesh_left,
+                             equations, solver_left.surface_integral, solver_left,
+                             cache_left)
+        calc_interface_flux!(cache_right.surface_flux_values, u_right, mesh_right,
+                             equations, solver_right.surface_integral, solver_right,
+                             cache_right)
+    end
+
+    @trixi_timeit timer() "boundary flux" begin
+        surface_flux_values = (cache_left.surface_flux_values,
+                               cache_right.surface_flux_values)
+        surface_integral = (solver_left.surface_integral, solver_right.surface_integral)
+        calc_boundary_flux!(surface_flux_values, u, t,
+                            boundary_conditions, mesh, equations,
+                            surface_integral, solver)
+    end
+
+    @trixi_timeit timer() "surface integral" begin
+        calc_surface_integral!(du_left, u_left, mesh_left, equations,
+                               solver_left.surface_integral, solver_left, cache_left)
+        calc_surface_integral!(du_right, u_right, mesh_right, equations,
+                               solver_right.surface_integral, solver_right, cache_right)
+    end
+
+    @trixi_timeit timer() "Jacobian" begin
+        apply_jacobian!(du_left, mesh_left, equations,
+                        solver_left, cache_left)
+        apply_jacobian!(du_right, mesh_right, equations,
+                        solver_right, cache_right)
+    end
 end
 
 function calc_boundary_flux!(surface_flux_values, u, t, boundary_conditions,
                              mesh::OversetGridMesh, equations,
-                             integral::AbstractSurfaceIntegral, solver)
+                             integral::Tuple, solver)
+    surface_flux_values_left, surface_flux_values_right = surface_flux_values
     u_left, u_right = u
     (; x_neg, x_pos) = boundary_conditions
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
-    surface_flux_values_left, surface_flux_values_right = surface_flux_values
+    integral_left, integral_right = integral
     solver_left, solver_right = solver
 
     # Left boundary condition of left mesh
     u_ll = x_neg(u, xmin(mesh), t, mesh, equations, solver, true)
     u_rr = get_node_vars(u_left, equations, 1, 1)
-    f = integral.surface_flux_boundary(u_ll, u_rr, equations)
+    f = integral_left.surface_flux_boundary(u_ll, u_rr, equations)
     set_node_vars!(surface_flux_values_left, f, equations, 1, 1)
 
     # Right boundary condition of left mesh
@@ -154,7 +143,7 @@ function calc_boundary_flux!(surface_flux_values, u, t, boundary_conditions,
         values = u_right[v, :, l_right]
         u_rr[v] = e_M_right' * values
     end
-    f = integral.surface_flux_boundary(u_ll, u_rr, equations)
+    f = integral_left.surface_flux_boundary(u_ll, u_rr, equations)
     set_node_vars!(surface_flux_values_left, f, equations, 2, nelements(mesh_left))
 
     # Left boundary condition of right mesh
@@ -171,57 +160,15 @@ function calc_boundary_flux!(surface_flux_values, u, t, boundary_conditions,
         u_ll[v] = e_M_left' * values
     end
     u_rr = get_node_vars(u_right, equations, 1, 1)
-    f = integral.surface_flux_boundary(u_ll, u_rr, equations)
+    f = integral_right.surface_flux_boundary(u_ll, u_rr, equations)
     set_node_vars!(surface_flux_values_right, f, equations, 1, 1)
 
     # Right boundary condition of right mesh
     u_ll = get_node_vars(u_right, equations, nnodes(solver_right, nelements(mesh_right)),
                          nelements(mesh_right))
     u_rr = x_pos(u, xmax(mesh), t, mesh, equations, solver, false)
-    f = integral.surface_flux_boundary(u_ll, u_rr, equations)
+    f = integral_right.surface_flux_boundary(u_ll, u_rr, equations)
     set_node_vars!(surface_flux_values_right, f, equations, 2, nelements(mesh_right))
-end
-
-function calc_surface_integral!(du, u, mesh::OversetGridMesh, equations,
-                                integral::SurfaceIntegralWeakForm,
-                                solver, cache)
-    du_left, du_right = du
-    u_left, u_right = u
-    surface_flux_values_left, surface_flux_values_right = cache.surface_flux_values
-    solver_left, solver_right = solver
-    surface_operator_left, surface_operator_right = cache.surface_operator
-    calc_surface_integral!(du_left, u_left, mesh.mesh_left, equations,
-                           integral, solver_left, surface_operator_left,
-                           surface_flux_values_left)
-    calc_surface_integral!(du_right, u_right, mesh.mesh_right, equations,
-                           integral, solver_right, surface_operator_right,
-                           surface_flux_values_right)
-end
-
-function calc_surface_integral!(du, u, mesh::OversetGridMesh, equations,
-                                integral::SurfaceIntegralStrongForm,
-                                solver, cache)
-    du_left, du_right = du
-    u_left, u_right = u
-    surface_flux_values_left, surface_flux_values_right = cache.surface_flux_values
-    solver_left, solver_right = solver
-    surface_operator_left_left, surface_operator_right_left = cache.surface_operator_left
-    surface_operator_left_right, surface_operator_right_right = cache.surface_operator_right
-    calc_surface_integral!(du_left, u_left, mesh.mesh_left, equations,
-                           integral, solver_left, surface_operator_left_left,
-                           surface_operator_left_right, surface_flux_values_left)
-    calc_surface_integral!(du_right, u_right, mesh.mesh_right, equations,
-                           integral, solver_right, surface_operator_right_left,
-                           surface_operator_right_right, surface_flux_values_right)
-end
-
-function apply_jacobian!(du, mesh::OversetGridMesh, equations, solver, cache)
-    du_left, du_right = du
-    jacobian_left, jacobian_right = cache.jacobian
-    mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
-    solver_left, solver_right = solver
-    apply_jacobian!(du_left, mesh_left, equations, solver_left, cache, jacobian_left)
-    apply_jacobian!(du_right, mesh_right, equations, solver_right, cache, jacobian_right)
 end
 
 # This method is for integrating a vector quantity for all variables over the entire domain,
@@ -256,9 +203,12 @@ function PolynomialBases.integrate(func,
                                                                                                     Vector{Vector{T}}}}
                                                                                }
     u_left, u_right = u
-    jacobian_left, jacobian_right = semi.cache.jacobian
+    jacobian_left, jacobian_right = semi.cache.cache_left.jacobian,
+                                    semi.cache.cache_right.jacobian
+    mesh_left, mesh_right = semi.mesh.mesh_left, semi.mesh.mesh_right
     solver_left, solver_right = semi.solver
     l_left = left_overlap_element(semi.mesh)
+    l_right = right_overlap_element(semi.mesh)
     # TODO: This integrates the left domain only until the left boundary of the left overlap element,
     # i.e., we miss the integral from the left boundary of the left overlap element to b.
     # TODO: Which part should be integrated in the overlap region? This uses the right mesh,
@@ -266,67 +216,69 @@ function PolynomialBases.integrate(func,
     integral_left = sum(integrate_on_element(func, u_left.u[element],
                                              get_basis(solver_left, element), element,
                                              jacobian_left)
-                        for element in 1:l_left)
+                        for element in 1:nelements(mesh_left))
     integral_right = sum(integrate_on_element(func, u_right.u[element],
                                               get_basis(solver_right, element),
                                               element, jacobian_right)
-                         for element in 1:nelements(semi.mesh.mesh_right))
+                         for element in l_right:nelements(mesh_right))
     return integral_left + integral_right
 end
 
-function integrate_quantity!(quantity, func, u, semi::SemidiscretizationOversetGrid)
-    mesh, equations, solver, _ = mesh_equations_solver_cache(semi)
+function integrate_quantity(func, u, semi::SemidiscretizationOversetGrid)
+    mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
     u_left, u_right = u
-    quantity_left, quantity_right = quantity
+    cache_left, cache_right = cache
+    quantity_left, quantity_right = get_tmp_cache_scalar(cache_left),
+                                    get_tmp_cache_scalar(cache_right)
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
     compute_quantity!(quantity_left, func, u_left, mesh_left, equations, solver_left)
     compute_quantity!(quantity_right, func, u_right, mesh_right, equations, solver_right)
+    quantity = VectorOfArray([quantity_left, quantity_right])
     integrate(quantity, semi)
 end
 
 function analyze(::typeof(entropy_timederivative), du, u, t,
                  semi::SemidiscretizationOversetGrid)
-    mesh, equations, solver, _ = mesh_equations_solver_cache(semi)
+    mesh, equations, solver, cache = mesh_equations_solver_cache(semi)
     u_left, u_right = u
     du_left, du_right = du
-    quantity = get_tmp_cache_scalar(semi)
-    quantity_left, quantity_right = quantity
+    cache_left, cache_right = cache
+    quantity_left, quantity_right = get_tmp_cache_scalar(cache_left),
+                                    get_tmp_cache_scalar(cache_right)
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
     compute_quantity_timederivative!(quantity_left, cons2entropy, du_left, u_left,
                                      mesh_left, equations, solver_left)
     compute_quantity_timederivative!(quantity_right, cons2entropy, du_right, u_right,
                                      mesh_right, equations, solver_right)
+    quantity = VectorOfArray([quantity_left, quantity_right])
     return integrate(quantity, semi)
 end
 
 function calc_error_norms(u, t, initial_condition, mesh::OversetGridMesh,
                           equations, solver, cache)
     u_left, u_right = u
-    jacobian_left, jacobian_right = cache.jacobian
-    node_coordinates_left, node_coordinates_right = cache.node_coordinates
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
+    cache_left, cache_right = cache
     l2_error_left, linf_error_left = calc_error_norms(u_left, t, initial_condition,
                                                       mesh_left, equations,
-                                                      solver_left, cache, jacobian_left,
-                                                      node_coordinates_left)
+                                                      solver_left, cache_left)
     l2_error_right, linf_error_right = calc_error_norms(u_right, t, initial_condition,
                                                         mesh_right, equations,
-                                                        solver_right, cache, jacobian_right,
-                                                        node_coordinates_right)
+                                                        solver_right, cache_right)
     return l2_error_left + l2_error_right, max(linf_error_left, linf_error_right)
 end
 
-function max_dt(u, t, mesh::OversetGridMesh, equations, solver, jacobian)
+function max_dt(u, t, mesh::OversetGridMesh, equations, solver, cache)
     u_left, u_right = u
-    jacobian_left, jacobian_right = jacobian
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
+    cache_left, cache_right = cache
     max_scaled_speed_left = max_dt(u_left, t, mesh_left, equations, solver_left,
-                                   jacobian_left)
+                                   cache_left)
     max_scaled_speed_right = max_dt(u_right, t, mesh_right, equations, solver_right,
-                                    jacobian_right)
+                                    cache_right)
     return max(max_scaled_speed_left, max_scaled_speed_right)
 end

--- a/src/solvers/dg.jl
+++ b/src/solvers/dg.jl
@@ -104,12 +104,7 @@ function allocate_coefficients(mesh, equations, solver)
 end
 
 function compute_coefficients!(u, func, t, mesh, equations, solver, cache)
-    compute_coefficients!(u, func, t, mesh, equations, solver, cache,
-                          cache.node_coordinates)
-end
-
-function compute_coefficients!(u, func, t, mesh, equations, solver,
-                               cache, node_coordinates)
+    node_coordinates = cache.node_coordinates
     for element in eachelement(mesh)
         for i in eachnode(solver, element)
             x_node = get_node_coords(node_coordinates, equations, solver, i, element)

--- a/src/solvers/solver.jl
+++ b/src/solvers/solver.jl
@@ -31,15 +31,8 @@ end
 
 function calc_error_norms(u, t, initial_condition, mesh, equations,
                           solver, cache)
-    calc_error_norms(u, t, initial_condition, mesh, equations,
-                     solver, cache, cache.jacobian, cache.node_coordinates)
-end
-
-function calc_error_norms(u, t, initial_condition, mesh, equations,
-                          solver, cache, jacobian, node_coordinates)
     u_exact = similar(u)
-    compute_coefficients!(u_exact, initial_condition, t, mesh, equations, solver, cache,
-                          node_coordinates)
+    compute_coefficients!(u_exact, initial_condition, t, mesh, equations, solver, cache)
     l2_error = zeros(real(solver), nvariables(equations))
     linf_error = zeros(real(solver), nvariables(equations))
     for v in eachvariable(equations)
@@ -51,7 +44,7 @@ function calc_error_norms(u, t, initial_condition, mesh, equations,
             for i in eachnode(solver, element)
                 diff[i] = u[v, i, element] - u_exact[v, i, element]
             end
-            l2_error[v] += jacobian[element] *
+            l2_error[v] += cache.jacobian[element] *
                            integrate(abs2, diff, get_basis(solver, element))
             linf_error[v] = max(linf_error[v], maximum(abs.(diff)))
         end


### PR DESCRIPTION
This simplifies the `cache` of the overset grid method by splitting it into a `cache_left` and `cache_right`, which means we need to specialize less function, but now have a custom specialized `rhs!` function. This also allows us to not rely on the very hacky `Base.getproperty` overwrite for the tuple of `solvers`, which always picked the first solver (meaning both solvers necessarily needed the same surface and volume integrals, which is now not required anymore).