### PR TITLE
Add `plot_analytical` to plot recipes

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,11 +1,13 @@
 struct PlotData{Conversion}
     semisol::Pair{<:Semidiscretization, <:ODESolution}
     plot_initial::Bool
+    plot_analytical::Bool
     conversion::Conversion
     step::Integer
 end
 
-@recipe function f(semi::Semidiscretization, data, data_exact, names, plot_initial)
+@recipe function f(semi::Semidiscretization, data, data_initial, data_exact, names,
+                   plot_initial, plot_analytical)
     x = flat_grid(semi)
     for i in eachindex(names)
         if plot_initial == true
@@ -15,34 +17,54 @@ end
                 xguide --> "x"
                 yguide --> names[i]
                 title --> names[i]
+                x, view(data_initial, i, :)
+            end
+        end
+        if plot_analytical == true
+            @series begin
+                subplot --> i
+                label --> "analytical $(names[i])"
+                xguide --> "x"
+                yguide --> names[i]
+                title --> names[i]
                 x, view(data_exact, i, :)
             end
         end
         @series begin
             subplot --> i
             label --> names[i]
-            linestyle --> :solid
             x, view(data, i, :)
         end
     end
 end
 
-@recipe function f(semi::SemidiscretizationOversetGrid, data, data_exact, names,
-                   plot_initial)
+@recipe function f(semi::SemidiscretizationOversetGrid, data, data_initial, data_exact,
+                   names, plot_initial, plot_analytical)
     x_left, x_right = flat_grid(semi)
     for i in eachindex(names)
         if plot_initial == true
+            data_initial_left, data_initial_right = data_initial
+            @series begin
+                subplot --> i
+                label --> "initial $(names[i]) left"
+                x_left, view(data_initial_left, i, :)
+            end
+            @series begin
+                subplot --> i
+                label --> "initial $(names[i]) right"
+                x_right, view(data_initial_right, i, :)
+            end
+        end
+        if plot_analytical == true
             data_exact_left, data_exact_right = data_exact
             @series begin
                 subplot --> i
-                linestyle --> :solid
-                label --> "initial $(names[i]) left"
+                label --> "analytical $(names[i]) left"
                 x_left, view(data_exact_left, i, :)
             end
             @series begin
                 subplot --> i
-                linestyle --> :solid
-                label --> "initial $(names[i]) right"
+                label --> "analytical $(names[i]) right"
                 x_right, view(data_exact_right, i, :)
             end
         end
@@ -66,28 +88,50 @@ end
     end
 end
 
-function compute_data(mesh::OversetGridMesh, equations, solver, u, u_exact, plot_initial,
-                      conversion, nvars)
+function compute_data(mesh::OversetGridMesh, equations, solver, u, u_initial, u_exact,
+                      plot_initial, plot_analytical, conversion, nvars)
     mesh_left, mesh_right = mesh.mesh_left, mesh.mesh_right
     solver_left, solver_right = solver
     u_left, u_right = u
+
+    if isnothing(u_initial)
+        u_initial_left, u_initial_right = nothing, nothing
+    else
+        u_initial_left, u_initial_right = u_initial
+    end
     if isnothing(u_exact)
         u_exact_left, u_exact_right = nothing, nothing
     else
         u_exact_left, u_exact_right = u_exact
     end
 
-    data_left, data_left_exact = compute_data(mesh_left, equations, solver_left, u_left,
-                                              u_exact_left, plot_initial, conversion, nvars)
-    data_right, data_right_exact = compute_data(mesh_right, equations, solver_right,
-                                                u_right, u_exact_right, plot_initial,
-                                                conversion, nvars)
-    return (data_left, data_right), (data_left_exact, data_right_exact)
+    data_left, data_initial_left, data_exact_left = compute_data(mesh_left, equations,
+                                                                 solver_left, u_left,
+                                                                 u_initial_left,
+                                                                 u_exact_left, plot_initial,
+                                                                 plot_analytical,
+                                                                 conversion, nvars)
+    data_right, data_initial_right, data_exact_right = compute_data(mesh_right, equations,
+                                                                    solver_right,
+                                                                    u_right,
+                                                                    u_initial_right,
+                                                                    u_exact_right,
+                                                                    plot_initial,
+                                                                    plot_analytical,
+                                                                    conversion, nvars)
+    return (data_left, data_right), (data_initial_left, data_initial_right),
+           (data_exact_left, data_exact_right)
 end
 
-function compute_data(mesh, equations, solver, u, u_exact, plot_initial, conversion, nvars)
+function compute_data(mesh, equations, solver, u, u_initial, u_exact, plot_initial,
+                      plot_analytical, conversion, nvars)
     data = zeros(real(mesh), nvars, ndofs(mesh, solver))
     if plot_initial == true
+        data_initial = zeros(real(mesh), nvars, ndofs(mesh, solver))
+    else
+        data_initial = nothing
+    end
+    if plot_analytical == true
         data_exact = zeros(real(mesh), nvars, ndofs(mesh, solver))
     else
         data_exact = nothing
@@ -97,17 +141,21 @@ function compute_data(mesh, equations, solver, u, u_exact, plot_initial, convers
         for node in eachnode(solver, element)
             data[:, j] .= conversion(get_node_vars(u, equations, node, element), equations)
             if plot_initial == true
+                data_initial[:, j] .= conversion(get_node_vars(u_initial, equations, node,
+                                                               element), equations)
+            end
+            if plot_analytical == true
                 data_exact[:, j] .= conversion(get_node_vars(u_exact, equations, node,
                                                              element), equations)
             end
             j += 1
         end
     end
-    return data, data_exact
+    return data, data_initial, data_exact
 end
 
 @recipe function f(plotdata::PlotData)
-    @unpack semisol, plot_initial, conversion, step = plotdata
+    @unpack semisol, plot_initial, plot_analytical, conversion, step = plotdata
     semi, sol = semisol
     mesh, equations, solver, _ = mesh_equations_solver_cache(semi)
     names = varnames(conversion, equations)
@@ -121,29 +169,37 @@ end
     initial_condition = semi.initial_condition
     t = sol.t[step]
     u = sol.u[step]
+
     if plot_initial
+        u_initial = compute_coefficients(initial_condition, zero(t), semi)
+    else
+        u_initial = nothing
+    end
+    if plot_analytical
         u_exact = compute_coefficients(initial_condition, t, semi)
     else
         u_exact = nothing
     end
 
-    data, data_exact = compute_data(mesh, equations, solver, u, u_exact, plot_initial,
-                                    conversion, nvars)
+    data, data_initial, data_exact = compute_data(mesh, equations, solver,
+                                                  u, u_initial, u_exact,
+                                                  plot_initial, plot_analytical,
+                                                  conversion, nvars)
 
     plot_title --> "$(get_name(equations)) at t = $(round(t, digits=5))"
     layout --> nvars
 
-    return semi, data, data_exact, names, plot_initial
+    return semi, data, data_initial, data_exact, names, plot_initial, plot_analytical
 end
 
 @recipe function f(semisol::Pair{<:Semidiscretization, <:ODESolution}; plot_initial = false,
-                   conversion = cons2prim, step = -1)
-    return PlotData(semisol, plot_initial, conversion, step)
+                   plot_analytical = false, conversion = cons2prim, step = -1)
+    return PlotData(semisol, plot_initial, plot_analytical, conversion, step)
 end
 
 @recipe function f(semi::Semidiscretization, sol::ODESolution; plot_initial = false,
-                   conversion = cons2prim, step = -1)
-    return PlotData(semi => sol, plot_initial, conversion, step)
+                   plot_analytical = false, conversion = cons2prim, step = -1)
+    return PlotData(semi => sol, plot_initial, plot_analytical, conversion, step)
 end
 
 function pretty_form_utf(name)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -371,6 +371,7 @@ end
     include(joinpath(EXAMPLES_DIR_ADVECTION, "linear_advection_per_element.jl"))
     @test_nowarn plot(flat_grid(semi), get_variable(sol.u[end], 1, semi))
     @test_nowarn plot(semi, sol, plot_initial = true, step = 6)
+    @test_nowarn plot(semi, sol, plot_initial = true, plot_analytical = true, step = 6)
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6, conversion = cons2cons)
     @test_nowarn plot(analysis_callback)
     @test_nowarn plot(analysis_callback, what = (:errors,))
@@ -378,6 +379,7 @@ end
 
     include(joinpath(EXAMPLES_DIR_ADVECTION, "linear_advection_overset_grid.jl"))
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6)
+    @test_nowarn plot(semi, sol, plot_initial = true, plot_analytical = true, step = 6)
     x_left, x_right = flat_grid(semi)
     u_left, u_right = get_variable(sol.u[end], 1, semi)
     @test_nowarn plot(x_left, u_left, label = "left")
@@ -386,7 +388,7 @@ end
     include(joinpath(EXAMPLES_DIR_ADVECTION,
                      "linear_advection_overset_grid_per_element.jl"))
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6)
-
+    @test_nowarn plot(semi => sol, plot_initial = true, plot_analytical = true, step = 6)
     include(joinpath(EXAMPLES_DIR_EULER, "compressible_euler_overset_grid.jl"))
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6)
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6, conversion = cons2cons)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -389,6 +389,7 @@ end
                      "linear_advection_overset_grid_per_element.jl"))
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6)
     @test_nowarn plot(semi => sol, plot_initial = true, plot_analytical = true, step = 6)
+
     include(joinpath(EXAMPLES_DIR_EULER, "compressible_euler_overset_grid.jl"))
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6)
     @test_nowarn plot(semi => sol, plot_initial = true, step = 6, conversion = cons2cons)


### PR DESCRIPTION
Before, `plot_initial` was misleading because it plotted the analytical solution if available. This adds a keyword to plot the analytical solution and lets `plot_initial` indeed plot the initial condition. See also https://github.com/NumericalMathematics/DispersiveShallowWater.jl/pull/277.